### PR TITLE
Testing to break the CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,14 +21,16 @@ on:
     - cron: '35 9 * * 6'
   workflow_run:
     workflows: ["CI"]      # Name of your CI workflow
-    types: [completed]
-    # branches:
-    #   - '**'
+    types: 
+      - completed
+    branches:
+      - ['develop', main]
     # Only run if CI succeeded
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   analyze:
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,11 +26,11 @@ on:
     branches:
       - '**'
     # Only run if CI succeeded
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   analyze:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   analyze:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ on:
     branches:
       - '**'
     # Only run if CI succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,16 +21,14 @@ on:
     - cron: '35 9 * * 6'
   workflow_run:
     workflows: ["CI"]      # Name of your CI workflow
-    types:
-      - completed
-    branches:
-      - '**'
+    types: [completed]
+    # branches:
+    #   - '**'
     # Only run if CI succeeded
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   analyze:
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,9 +27,8 @@ on:
     # if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
-  on-success:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     analyze:
+      if: ${{ github.event.workflow_run.conclusion == 'success' }}
       name: Analyze
       runs-on: ubuntu-latest
       permissions:
@@ -77,7 +76,3 @@ jobs:
 
         - name: Perform CodeQL Analysis
           uses: github/codeql-action/analyze@v2
-  on-failure:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - run: echo 'The triggering workflow failed'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,15 +12,15 @@
 name: 'CodeQL'
 
 on:
-  push:
-    branches: ['develop', main]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ['develop']
-  schedule:
-    - cron: '35 9 * * 6'
+  # push:
+  #   branches: ['develop', main]
+  # pull_request:
+  #   # The branches below must be a subset of the branches above
+  #   branches: ['develop']
+  # schedule:
+  #   - cron: '35 9 * * 6'
   workflow_run:
-    workflows: ["CI"]       # Must exactly match your CI workflow's name
+    workflows: [ "CI" ]       # Must exactly match your CI workflow's name
     types:
       - completed
     branches:
@@ -28,7 +28,7 @@ on:
 
 jobs:
   analyze:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,61 +20,64 @@ on:
   schedule:
     - cron: '35 9 * * 6'
   workflow_run:
-    workflows: ["CI"]      # Name of your CI workflow
+    workflows: [CI]      # Name of your CI workflow
     types: 
       - completed
-    branches:
-      - '**'
     # Only run if CI succeeded
     # if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
-  analyze:
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    name: Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
+  on-success:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    analyze:
+      name: Analyze
+      runs-on: ubuntu-latest
+      permissions:
+        actions: read
+        contents: read
+        security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ['javascript']
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+      strategy:
+        fail-fast: false
+        matrix:
+          language: ['javascript']
+          # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+          # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3
+
+        # Initializes the CodeQL tools for scanning.
+        - name: Initialize CodeQL
+          uses: github/codeql-action/init@v2
+          with:
+            languages: ${{ matrix.language }}
+            # If you wish to specify custom queries, you can do so here or in a config file.
+            # By default, queries listed here will override any specified in a config file.
+            # Prefix the list here with "+" to use these queries and those in the config file.
+
+            # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+            # queries: security-extended,security-and-quality
+
+        # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+        # If this step fails, then you should remove it and run the build manually (see below)
+        - name: Autobuild
+          uses: github/codeql-action/autobuild@v2
+
+        # ℹ️ Command-line programs to run using the OS shell.
+        # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+        #   If the Autobuild fails above, remove it and uncomment the following three lines.
+        #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+        # - run: |
+        #   echo "Run, Build Application using script"
+        #   ./location_of_script_within_repo/buildscript.sh
+
+        - name: Perform CodeQL Analysis
+          uses: github/codeql-action/analyze@v2
+  on-failure:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+      - run: echo 'The triggering workflow failed'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,14 @@ on:
     branches: ['develop']
   schedule:
     - cron: '35 9 * * 6'
+  workflow_run:
+    workflows: ["CI"]      # Name of your CI workflow
+    types:
+      - completed
+    branches:
+      - '**'
+    # Only run if CI succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,15 +12,15 @@
 name: 'CodeQL'
 
 on:
-  push:
-    branches: ['develop', main]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ['develop']
+  # push:
+  #   branches: ['develop', main]
+  # pull_request:
+  #   # The branches below must be a subset of the branches above
+  #   branches: ['develop']
   schedule:
     - cron: '35 9 * * 6'
   workflow_run:
-    workflows: [CI]      # Name of your CI workflow
+    workflows: ["CI"]      # Name of your CI workflow
     types: 
       - completed
     # Only run if CI succeeded

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,19 +12,19 @@
 name: 'CodeQL'
 
 on:
-  # push:
-  #   branches: ['develop', main]
-  # pull_request:
-  #   # The branches below must be a subset of the branches above
-  #   branches: ['develop']
-  # schedule:
-  #   - cron: '35 9 * * 6'
-  workflow_run:
-    workflows: [ "CI" ]       # Must exactly match your CI workflow's name
-    types:
-      - completed
-    branches:
-      - '**'   
+  push:
+    branches: ['develop', main]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ['develop']
+  schedule:
+    - cron: '35 9 * * 6'
+  # workflow_run:
+  #   workflows: [ "CI" ]       # Must exactly match your CI workflow's name
+  #   types:
+  #     - completed
+  #   branches:
+  #     - '**'   
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,67 +12,67 @@
 name: 'CodeQL'
 
 on:
-  # push:
-  #   branches: ['develop', main]
-  # pull_request:
-  #   # The branches below must be a subset of the branches above
-  #   branches: ['develop']
+  push:
+    branches: ['develop', main]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ['develop']
   schedule:
     - cron: '35 9 * * 6'
   workflow_run:
-    workflows: ["CI"]      # Name of your CI workflow
-    types: 
+    workflows: ["CI"]       # Must exactly match your CI workflow's name
+    types:
       - completed
-    # Only run if CI succeeded
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    branches:
+      - '**'   
 
 jobs:
-    analyze:
-      if: ${{ github.event.workflow_run.conclusion == 'success' }}
-      name: Analyze
-      runs-on: ubuntu-latest
-      permissions:
-        actions: read
-        contents: read
-        security-events: write
+  analyze:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
-      strategy:
-        fail-fast: false
-        matrix:
-          language: ['javascript']
-          # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-          # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-        # Initializes the CodeQL tools for scanning.
-        - name: Initialize CodeQL
-          uses: github/codeql-action/init@v2
-          with:
-            languages: ${{ matrix.language }}
-            # If you wish to specify custom queries, you can do so here or in a config file.
-            # By default, queries listed here will override any specified in a config file.
-            # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-            # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-            # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-        # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-        # If this step fails, then you should remove it and run the build manually (see below)
-        - name: Autobuild
-          uses: github/codeql-action/autobuild@v2
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-        # ℹ️ Command-line programs to run using the OS shell.
-        # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-        #   If the Autobuild fails above, remove it and uncomment the following three lines.
-        #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-        # - run: |
-        #   echo "Run, Build Application using script"
-        #   ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-        - name: Perform CodeQL Analysis
-          uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ on:
     branches:
       - ['develop', main]
     # Only run if CI succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ on:
     types: 
       - completed
     branches:
-      - ['develop', main]
+      - '**'
     # Only run if CI succeeded
     # if: ${{ github.event.workflow_run.conclusion == 'success' }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +33,7 @@ jobs:
             event: "pull_request",
             per_page: 5,
           });
+
           // Find the latest run for this PR
           const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
           if (runsForPR.length === 0) {
@@ -40,6 +41,7 @@ jobs:
             return;
           }
           const latestRun = runsForPR[0];
+
           if (latestRun.conclusion !== "success") {
             core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
           }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       uses: lewagon/wait-on-check-action@v1.3.4
       with:
         ref: ${{ github.ref }}
-        check-name: 'CI / build (14.x)'  # Exact name of your CI check
+        check-name: 'CI'  # Exact name of your CI check
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,10 @@ on:
     branches: [main, develop]
   push:
     branches: [main, develop]
-  # workflow_run:
-  #   workflows: ["CI"]      # Name of your CI workflow
-  #   types:
-  #     - completed
+  workflow_run:
+    workflows: ["CI"]      # Name of your CI workflow
+    types:
+      - completed
   #   branches:
   #     - '**'
   #   # Only run if CI succeeded

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
           const latestRun = completedRuns[0];
 
           if (latestRun.conclusion !== "success") {
-            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
+            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion, runsForPR}). Stopping Tests.`);
           }
     - name: Install system dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    
+      - name: Check if CI workflow succeeded
+        uses: actions/github-script@v6
+        id: check_ci
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const workflowName = "CI"; // Name of your CI workflow
+            const runs = await github.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowName,
+              branch: context.payload.pull_request.head.ref,
+              event: "pull_request",
+              per_page: 5,
+            });
+
+            // Find the latest run for this PR
+            const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
+            if (runsForPR.length === 0) {
+              core.setFailed("No CI workflow run found for this PR.");
+              return;
+            }
+            const latestRun = runsForPR[0];
+
+            if (latestRun.conclusion !== "success") {
+              core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
+            }
 
     - name: Install system dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
       - '**'   
 
 jobs:
+  if: ${{ github.event.workflow_run.conclusion == 'success' }}
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,71 +1,57 @@
 name: Tests
-
 on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
   workflow_run:
-    workflows: ["CI"]      # Must exactly match your CI workflow name
+    workflows: ["CI"]      # Name of your CI workflow
     types:
       - completed
-    branches: 
-      - '**'              
+  #   branches:
+  #     - '**'
+  #   # Only run if CI succeeded
+  #   if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Check if CI workflow succeeded
-        uses: actions/github-script@v6
-        id: check_ci
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const core = require('@actions/core');
-            const workflowRun = context.payload.workflow_run;
+    - name: Check if CI workflow succeeded
+      uses: actions/github-script@v6
+      id: check_ci
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const prNumber = context.payload.pull_request.number;
+          const workflowName = "CI"; // Name of your CI workflow
+          const runs = await github.rest.actions.listWorkflowRunsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: workflowName,
+            branch: context.payload.pull_request.head.ref,
+            event: "pull_request",
+            per_page: 5,
+          });
 
-            // Validate presence of associated PRs
-            if (!workflowRun || !workflowRun.pull_requests || workflowRun.pull_requests.length === 0) {
-              core.setFailed("No associated pull requests found for this workflow run. Cannot proceed with Tests.");
-              return;
-            }
+          // Find the latest run for this PR
+          const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
+          if (runsForPR.length === 0) {
+            core.setFailed("No CI workflow run found for this PR.");
+            return;
+          }
+          const latestRun = runsForPR[0];
 
-            const pr = workflowRun.pull_requests[0];
-            const prNumber = pr.number;
-            const prBranch = pr.head.ref;
+          if (latestRun.conclusion !== "success") {
+            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
+          }
+    - name: Install system dependencies
+      run: |
+        echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+    - name: Install project dependencies
+      run: yarn install
 
-            const workflowName = "CI"; // Your CI workflow name
-
-            // Fetch recent workflow runs for this PR branch and workflow
-            const runs = await github.rest.actions.listWorkflowRunsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: workflowName,
-              branch: prBranch,
-              event: "pull_request",
-              per_page: 5,
-            });
-
-            // Filter runs associated with this PR number
-            const runsForPR = runs.data.workflow_runs.filter(run =>
-              run.pull_requests.some(pr => pr.number === prNumber)
-            );
-
-            if (runsForPR.length === 0) {
-              core.setFailed(`No CI workflow run found for PR #${prNumber}. Cannot proceed with Tests.`);
-              return;
-            }
-
-            const latestRun = runsForPR[0];
-            if (latestRun.conclusion !== "success") {
-              core.setFailed(`CI workflow for PR #${prNumber} did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
-            }
-
-      - name: Install system dependencies
-        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-
-      - name: Install project dependencies
-        run: yarn install
-
-      - name: Run tests
-        run: yarn test
+    - name: Run tests
+      run: yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,14 @@
 name: Tests
 on:
-  pull_request:
-    branches: [main, develop]
-  push:
-    branches: [main, develop]
-  # workflow_run:
-  #   workflows: [ "CI" ]       # Must exactly match your CI workflow's name
-  #   types:
-  #     - completed
-  #   branches:
-  #     - '**'   
+  # pull_request:
+  #   branches: [main, develop]
+  # push:
+  #   branches: [main, develop]
+  workflow_run:
+    workflows: [ "CI" ]       # Must exactly match your CI workflow's name
+    types:
+      - completed
+    branches: [main, develop] 
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,11 @@ on:
   push:
     branches: [main, develop]
   workflow_run:
-    workflows: ["CodeQL"]      # Name of your CodeQL workflow
+    workflows: [ "CI" ]       # Must exactly match your CI workflow's name
     types:
       - completed
     branches:
-      - '**'
-    # Only run if CodeQL succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+      - '**'   
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,7 @@ on:
     workflows: ["CI"]      # Must exactly match your CI workflow name
     types:
       - completed
-    branches:
-      - '**'               # Adjust branches as needed
+    branches: [develop, main]              # Adjust branches as needed
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ on:
       - '**'   
 
 jobs:
-  if: ${{ github.event.workflow_run.conclusion == 'success' }}
   test:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,16 @@ name: Tests
 
 on:
   workflow_run:
-    workflows: ["CI"] # Name of your CI workflow
+    workflows: ["CI"]      # Must exactly match your CI workflow name
     types:
       - completed
+    branches:
+      - '**'               # Adjust branches as needed
 
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 
@@ -18,32 +21,48 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = context.payload.pull_request.number;
-            const workflowName = "CI"; // Name of your CI workflow
+            const core = require('@actions/core');
+            const workflowRun = context.payload.workflow_run;
+
+            // Validate presence of associated PRs
+            if (!workflowRun || !workflowRun.pull_requests || workflowRun.pull_requests.length === 0) {
+              core.setFailed("No associated pull requests found for this workflow run. Cannot proceed with Tests.");
+              return;
+            }
+
+            const pr = workflowRun.pull_requests[0];
+            const prNumber = pr.number;
+            const prBranch = pr.head.ref;
+
+            const workflowName = "CI"; // Your CI workflow name
+
+            // Fetch recent workflow runs for this PR branch and workflow
             const runs = await github.rest.actions.listWorkflowRunsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: workflowName,
-              branch: context.payload.pull_request.head.ref,
+              branch: prBranch,
               event: "pull_request",
               per_page: 5,
             });
 
-            // Find the latest run for this PR
-            const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
+            // Filter runs associated with this PR number
+            const runsForPR = runs.data.workflow_runs.filter(run =>
+              run.pull_requests.some(pr => pr.number === prNumber)
+            );
+
             if (runsForPR.length === 0) {
-              core.setFailed("No CI workflow run found for this PR.");
+              core.setFailed(`No CI workflow run found for PR #${prNumber}. Cannot proceed with Tests.`);
               return;
             }
-            const latestRun = runsForPR[0];
 
+            const latestRun = runsForPR[0];
             if (latestRun.conclusion !== "success") {
-              core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
+              core.setFailed(`CI workflow for PR #${prNumber} did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
             }
 
       - name: Install system dependencies
-        run: |
-          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: Install project dependencies
         run: yarn install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
           const latestRun = completedRuns[0];
 
           if (latestRun.conclusion !== "success") {
-            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion, runsForPR}). Stopping Tests.`);
+            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
           }
     - name: Install system dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
+          const core = require('@actions/core');
           const prNumber = context.payload.pull_request.number;
           const workflowName = "CI"; // Name of your CI workflow
           const runs = await github.rest.actions.listWorkflowRunsForRepo({
@@ -33,16 +34,23 @@ jobs:
             workflow_id: workflowName,
             branch: context.payload.pull_request.head.ref,
             event: "pull_request",
-            per_page: 5,
+            per_page: 10,
           });
 
-          // Find the latest run for this PR
-          const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
-          if (runsForPR.length === 0) {
-            core.setFailed("No CI workflow run found for this PR.");
+          // Filter runs for this PR
+          const runsForPR = runs.data.workflow_runs.filter(run =>
+            run.pull_requests.some(pr => pr.number === prNumber)
+          );
+
+          // Filter only completed runs
+          const completedRuns = runsForPR.filter(run => run.status === "completed");
+
+          if (completedRuns.length === 0) {
+            core.setFailed("No completed CI workflow run found for this PR. Please wait for CI to finish.");
             return;
           }
-          const latestRun = runsForPR[0];
+
+          const latestRun = completedRuns[0];
 
           if (latestRun.conclusion !== "success") {
             core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          const core = require('@actions/core');
           const prNumber = context.payload.pull_request.number;
           const workflowName = "CI"; // Name of your CI workflow
           const runs = await github.rest.actions.listWorkflowRunsForRepo({

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Wait for CI to complete
+      uses: lewagon/wait-on-check-action@v1.3.4
+      with:
+        ref: ${{ github.ref }}
+        check-name: 'CI / build (14.x)'  # Exact name of your CI check
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 30
+
     - name: Check if CI workflow succeeded
       uses: actions/github-script@v6
       id: check_ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches: [main, develop]
   workflow_run:
-    workflows: ["CodeQL"]      # Name of your CI workflow
+    workflows: ["CodeQL"]      # Name of your CodeQL workflow
     types:
       - completed
     branches:
       - '**'
-    # Only run if CI succeeded
+    # Only run if CodeQL succeeded
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,14 @@ on:
     branches: [main, develop]
   push:
     branches: [main, develop]
+  workflow_run:
+    workflows: ["CI"]      # Name of your CI workflow
+    types:
+      - completed
+    branches:
+      - '**'
+    # Only run if CI succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,35 +19,34 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-      - name: Check if CI workflow succeeded
-        uses: actions/github-script@v6
-        id: check_ci
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const workflowName = "CI"; // Name of your CI workflow
-            const runs = await github.actions.listWorkflowRunsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: workflowName,
-              branch: context.payload.pull_request.head.ref,
-              event: "pull_request",
-              per_page: 5,
-            });
+    - name: Check if CI workflow succeeded
+      uses: actions/github-script@v6
+      id: check_ci
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const prNumber = context.payload.pull_request.number;
+          const workflowName = "CI"; // Name of your CI workflow
+          const runs = await github.actions.listWorkflowRunsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: workflowName,
+            branch: context.payload.pull_request.head.ref,
+            event: "pull_request",
+            per_page: 5,
+          });
 
-            // Find the latest run for this PR
-            const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
-            if (runsForPR.length === 0) {
-              core.setFailed("No CI workflow run found for this PR.");
-              return;
-            }
-            const latestRun = runsForPR[0];
+          // Find the latest run for this PR
+          const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
+          if (runsForPR.length === 0) {
+            core.setFailed("No CI workflow run found for this PR.");
+            return;
+          }
+          const latestRun = runsForPR[0];
 
-            if (latestRun.conclusion !== "success") {
-              core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
-            }
-
+          if (latestRun.conclusion !== "success") {
+            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
+          }
     - name: Install system dependencies
       run: |
         echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   test:
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
-  pull_request:
-    branches: [main, develop]
-  push:
-    branches: [main, develop]
+  # pull_request:
+  #   branches: [main, develop]
+  # push:
+  #   branches: [main, develop]
   workflow_run:
     workflows: [ "CI" ]       # Must exactly match your CI workflow's name
     types:
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
-  pull_request:
-    branches: [main, develop]
-  push:
-    branches: [main, develop]
+  # pull_request:
+  #   branches: [main, develop]
+  # push:
+  #   branches: [main, develop]
   workflow_run:
     workflows: ["CI"]      # Name of your CI workflow
     types:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         script: |
           const prNumber = context.payload.pull_request.number;
           const workflowName = "CI"; // Name of your CI workflow
-          const runs = await github.actions.listWorkflowRunsForRepo({
+          const runs = await github.rest.actions.listWorkflowRunsForRepo({
             owner: context.repo.owner,
             repo: context.repo.repo,
             workflow_id: workflowName,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,13 @@ on:
   push:
     branches: [main, develop]
   workflow_run:
-    workflows: ["CI"]      # Name of your CI workflow
+    workflows: ["CodeQL"]      # Name of your CI workflow
     types:
       - completed
-  #   branches:
-  #     - '**'
-  #   # Only run if CI succeeded
-  #   if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    branches:
+      - '**'
+    # Only run if CI succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   test:
@@ -19,34 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Check if CI workflow succeeded
-      uses: actions/github-script@v6
-      id: check_ci
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const prNumber = context.payload.pull_request.number;
-          const workflowName = "CI"; // Name of your CI workflow
-          const runs = await github.rest.actions.listWorkflowRunsForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: workflowName,
-            branch: context.payload.pull_request.head.ref,
-            event: "pull_request",
-            per_page: 5,
-          });
-
-          // Find the latest run for this PR
-          const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
-          if (runsForPR.length === 0) {
-            core.setFailed("No CI workflow run found for this PR.");
-            return;
-          }
-          const latestRun = runsForPR[0];
-
-          if (latestRun.conclusion !== "success") {
-            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
-          }
     - name: Install system dependencies
       run: |
         echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,56 +1,53 @@
 name: Tests
+
 on:
-  # pull_request:
-  #   branches: [main, develop]
-  # push:
-  #   branches: [main, develop]
   workflow_run:
-    workflows: [ "CI" ]       # Must exactly match your CI workflow's name
+    workflows: ["CI"] # Name of your CI workflow
     types:
       - completed
-    branches: [main, develop] 
 
 jobs:
   test:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Check if CI workflow succeeded
-      uses: actions/github-script@v6
-      id: check_ci
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const prNumber = context.payload.pull_request.number;
-          const workflowName = "CI"; // Name of your CI workflow
-          const runs = await github.rest.actions.listWorkflowRunsForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: workflowName,
-            branch: context.payload.pull_request.head.ref,
-            event: "pull_request",
-            per_page: 5,
-          });
+      - name: Check if CI workflow succeeded
+        uses: actions/github-script@v6
+        id: check_ci
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const workflowName = "CI"; // Name of your CI workflow
+            const runs = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowName,
+              branch: context.payload.pull_request.head.ref,
+              event: "pull_request",
+              per_page: 5,
+            });
 
-          // Find the latest run for this PR
-          const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
-          if (runsForPR.length === 0) {
-            core.setFailed("No CI workflow run found for this PR.");
-            return;
-          }
-          const latestRun = runsForPR[0];
+            // Find the latest run for this PR
+            const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
+            if (runsForPR.length === 0) {
+              core.setFailed("No CI workflow run found for this PR.");
+              return;
+            }
+            const latestRun = runsForPR[0];
 
-          if (latestRun.conclusion !== "success") {
-            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
-          }
+            if (latestRun.conclusion !== "success") {
+              core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
+            }
 
-    - name: Install system dependencies
-      run: |
-        echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-    - name: Install project dependencies
-      run: yarn install
+      - name: Install system dependencies
+        run: |
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
-    - name: Run tests
-      run: yarn test
+      - name: Install project dependencies
+        run: yarn install
+
+      - name: Run tests
+        run: yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,15 @@
 name: Tests
 on:
-  # pull_request:
-  #   branches: [main, develop]
-  # push:
-  #   branches: [main, develop]
-  workflow_run:
-    workflows: [ "CI" ]       # Must exactly match your CI workflow's name
-    types:
-      - completed
-    branches:
-      - '**'   
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  # workflow_run:
+  #   workflows: [ "CI" ]       # Must exactly match your CI workflow's name
+  #   types:
+  #     - completed
+  #   branches:
+  #     - '**'   
 
 jobs:
   test:
@@ -17,6 +17,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Check if CI workflow succeeded
+      uses: actions/github-script@v6
+      id: check_ci
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const prNumber = context.payload.pull_request.number;
+          const workflowName = "CI"; // Name of your CI workflow
+          const runs = await github.rest.actions.listWorkflowRunsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: workflowName,
+            branch: context.payload.pull_request.head.ref,
+            event: "pull_request",
+            per_page: 5,
+          });
+          // Find the latest run for this PR
+          const runsForPR = runs.data.workflow_runs.filter(run => run.pull_requests.some(pr => pr.number === prNumber));
+          if (runsForPR.length === 0) {
+            core.setFailed("No CI workflow run found for this PR.");
+            return;
+          }
+          const latestRun = runsForPR[0];
+          if (latestRun.conclusion !== "success") {
+            core.setFailed(`CI workflow failed or did not succeed (status: ${latestRun.conclusion}). Stopping Tests.`);
+          }
 
     - name: Install system dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,21 +4,21 @@ on:
     branches: [main, develop]
   push:
     branches: [main, develop]
-  workflow_run:
-    workflows: ["CI"]      # Name of your CI workflow
-    types:
-      - completed
-    branches:
-      - '**'
-    # Only run if CI succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  # workflow_run:
+  #   workflows: ["CI"]      # Name of your CI workflow
+  #   types:
+  #     - completed
+  #   branches:
+  #     - '**'
+  #   # Only run if CI succeeded
+  #   if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    
+
       - name: Check if CI workflow succeeded
         uses: actions/github-script@v6
         id: check_ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,8 @@ on:
     workflows: ["CI"]      # Must exactly match your CI workflow name
     types:
       - completed
-    branches: [develop, main]              # Adjust branches as needed
+    branches: 
+      - '**'              
 
 jobs:
   test:

--- a/index.html
+++ b/index.html
@@ -146,9 +146,9 @@
       <a id="application-button" href="/applications" class="action-button">
         Applications
       </a>
-        <a id="application-button" href="/test" class="action-button">
-          Test
-        </a>
+      <a id="test-button" href="/test" class="action-button">
+        Test
+      </a>
       <div class="button-container element-display-remove" id="sync-repo-div">
         <button id="repo-sync-button" class="action-button">
           <span class="spinner"></span>

--- a/index.html
+++ b/index.html
@@ -146,6 +146,9 @@
       <a id="application-button" href="/applications" class="action-button">
         Applications
       </a>
+        <a id="application-button" href="/test" class="action-button">
+          Test
+        </a>
       <div class="button-container element-display-remove" id="sync-repo-div">
         <button id="repo-sync-button" class="action-button">
           <span class="spinner"></span>

--- a/index.html
+++ b/index.html
@@ -146,9 +146,7 @@
       <a id="application-button" href="/applications" class="action-button">
         Applications
       </a>
-      <a id="test-button" href="/test" class="action-button"> 
-        Test 
-      </a>
+      <a id="test-button" href="/test" class="action-button"> Test </a>
       <div class="button-container element-display-remove" id="sync-repo-div">
         <button id="repo-sync-button" class="action-button">
           <span class="spinner"></span>

--- a/index.html
+++ b/index.html
@@ -146,7 +146,9 @@
       <a id="application-button" href="/applications" class="action-button">
         Applications
       </a>
-      <a id="test-button" href="/test" class="action-button"> Test </a>
+      <a id="test-button" href="/test" class="action-button"> 
+        Test 
+      </a>
       <div class="button-container element-display-remove" id="sync-repo-div">
         <button id="repo-sync-button" class="action-button">
           <span class="spinner"></span>

--- a/index.html
+++ b/index.html
@@ -146,9 +146,7 @@
       <a id="application-button" href="/applications" class="action-button">
         Applications
       </a>
-      <a id="test-button" href="/test" class="action-button">
-        Test
-      </a>
+      <a id="test-button" href="/test" class="action-button"> Test </a>
       <div class="button-container element-display-remove" id="sync-repo-div">
         <button id="repo-sync-button" class="action-button">
           <span class="spinner"></span>

--- a/navbar.global.js
+++ b/navbar.global.js
@@ -66,3 +66,7 @@ const addNavbartoPage = async () => {
     });
   }
 };
+function vulnerableXSS(userInput) {
+  // Dangerous: directly inserting user input into innerHTML
+  document.getElementById('output').innerHTML = userInput;
+}


### PR DESCRIPTION
This PR is to run pipelines. So that I can find it in the settings

Issue Num - [985](https://github.com/Real-Dev-Squad/website-dashboard/issues/985)

**Issue** - CI runs all jobs even if early checks like ESLint or Prettier fail. This means tests and deployments still run, even when the code isn't clean or build-ready.

**Resolution** - To fail the jobs early if one job is failing to save time and resources.